### PR TITLE
Bugfix

### DIFF
--- a/src/mps/InfMpo.m
+++ b/src/mps/InfMpo.m
@@ -223,8 +223,8 @@ classdef InfMpo
                     gl = twistdual(GL{d, sites(i)}, 1);
                     gr = GR{d, next(sites(i), period(mps))};
                     gr = twistdual(gr, nspaces(gr));
-                    gr_better = tpermute(gr, [1, flip(2:nspaces(gr)-1), nspaces(gr)]);
-                    gl_better = tpermute(gl, [1, flip(2:nspaces(gl)-1), nspaces(gl)]);
+                    gr_better = tpermute(gr, [1, flip(2:nspaces(gr)-1), nspaces(gr)], rank(gr));
+                    gl_better = tpermute(gl, [1, flip(2:nspaces(gl)-1), nspaces(gl)], rank(gl));
                     H{i}(d, 1) = FiniteMpo(gl_better, mpo.O(d, sites(i)), gr_better);
                 end
             end

--- a/src/sparse/SparseTensor.m
+++ b/src/sparse/SparseTensor.m
@@ -694,6 +694,15 @@ classdef (InferiorClasses = {?Tensor}) SparseTensor < AbstractTensor
         end
         
         function t = tpermute(t, p, r)
+            arguments
+                t
+                p = []
+                r = []
+            end
+            
+            if isempty(p), p = 1:nspaces(t); end
+            if isempty(r), r = rank(t); end
+
             for i = 1:numel(t.var)
                 t.var(i) = tpermute(t.var(i), p, r);
             end


### PR DESCRIPTION
Without this, tpermute throws the error 'Not enough input arguments'